### PR TITLE
Allow assigned unicode characters in merge tags

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -27,7 +27,7 @@ module Liquid
   TagStart                    = /\{\%/
   TagEnd                      = /\%\}/
   VariableSignature           = /\(?[\w\-\.\[\]]\)?/
-  VariableSegment             = /[\p{word}\-]/
+  VariableSegment             = /[\p{assigned}\-]/
   VariableStart               = /\{\{/
   VariableEnd                 = /\}\}/
   VariableIncompleteEnd       = /\}\}?/

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Liquid
-  VERSION = "3.0.6"
+  VERSION = "3.0.8"
 end


### PR DESCRIPTION
. Change the regex to allow merge tags to be populated with keys containing assigned unicode characters.
. Bump version.
