### PR TITLE
Fix variable name parsing

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -27,7 +27,7 @@ module Liquid
   TagStart                    = /\{\%/
   TagEnd                      = /\%\}/
   VariableSignature           = /\(?[\w\-\.\[\]]\)?/
-  VariableSegment             = /[\p{assigned}\-]/
+  VariableSegment             = /[^\s.]/
   VariableStart               = /\{\{/
   VariableEnd                 = /\}\}/
   VariableIncompleteEnd       = /\}\}?/

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Liquid
-  VERSION = "3.0.8"
+  VERSION = "3.0.9"
 end


### PR DESCRIPTION
https://redmine.wishpond.com/issues/104228445

## The problem

For arrays:

```
foo.size
foo[0]
```

and for hashes:

```
foo.bar
foo['bar']
```

They all return `nil`.

## Cause

We use a forked `liquid` gem that changes the variable name parser:

```diff
- VariableSegment             = /[\w\-]/
+ VariableSegment             = /[\p{assigned}\-]/
````

So any valid Unicode character can be used in variable names, including dots, brackets and even whitespaces, breaking the Liquid syntax.

## Solution
Instead of allowing any Unicode character in Liquid variable names, we accept any character except dots and whitespaces.

### AttributeMapping key parametrization
AttributeMapping keys get parametrized before validation so dots are removed and whitespaces are replaced by underscores.

### Limitations on square brackets
As square brackets are not removed from AttributeMapping keys, we need to keep them as valid variable characters, so we can't restore `foo['bar']` and `foo[0]`. Hopefully, we can live without them.